### PR TITLE
Token reward evaluators

### DIFF
--- a/backfeed_protocol/models/contribution.py
+++ b/backfeed_protocol/models/contribution.py
@@ -24,6 +24,8 @@ class Contribution(Base):
 
     max_score = Column(Float)
 
+    token_fund = Column(Float)
+
     def engaged_reputation(self):
         """return the total amount of reputation of users that have voted for this contribution"""
         return sum([evaluation.user.reputation for evaluation in self.evaluations])

--- a/backfeed_protocol/tests/test_contract_base.py
+++ b/backfeed_protocol/tests/test_contract_base.py
@@ -86,6 +86,9 @@ class ContractSanityTest(BaseContractTestCase):
         # we can retrieve the contribution from the contract
         self.assertEqual(contract.get_contributions(), [contribution1, contribution2])
 
+        # test token_fund initially equal to the contribution fee
+        self.assertEqual(contribution1.token_fund, contract.CONTRIBUTION_TYPE[contribution1.contribution_type]['fee'])
+
         # user2 evaluates the contribution
         value = 1.0
         evaluation1 = contract.create_evaluation(user1, contribution1, value=value)

--- a/backfeed_protocol/tests/test_evaluation.py
+++ b/backfeed_protocol/tests/test_evaluation.py
@@ -55,3 +55,7 @@ class EvaluationTest(BaseContractTestCase):
         self.assertEqual(user3.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])
         contract.create_evaluation(user4, contribution0, value=0)
         self.assertEqual(user4.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])
+
+        # check token balance unchanged when voting again
+        contract.create_evaluation(user1, contribution0, value=0)
+        self.assertEqual(user1.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])

--- a/backfeed_protocol/tests/test_evaluation.py
+++ b/backfeed_protocol/tests/test_evaluation.py
@@ -35,3 +35,23 @@ class EvaluationTest(BaseContractTestCase):
         self.assertEqual(len(contract.get_evaluations(evaluator_id=self.user1.id)), 1)
         self.assertEqual(len(contract.get_evaluations(evaluator_id=self.user2.id)), 2)
         self.assertEqual(len(contract.get_evaluations(evaluator_id=self.user3.id)), 2)
+
+    def test_token_rewards_for_evaluators(self):
+        contract = self.get_fresh_contract()
+        contract.REWARD_TOKENS_TO_EVALUATORS = True
+
+        user0 = contract.create_user()
+        user1 = contract.create_user()
+        user2 = contract.create_user()
+        user3 = contract.create_user()
+        user4 = contract.create_user()
+
+        contribution0 = contract.create_contribution(user=user0)
+        contract.create_evaluation(user1, contribution0, value=1)
+        self.assertEqual(user1.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])
+        contract.create_evaluation(user2, contribution0, value=0)
+        self.assertEqual(user2.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])
+        contract.create_evaluation(user3, contribution0, value=1)
+        self.assertEqual(user3.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])
+        contract.create_evaluation(user4, contribution0, value=0)
+        self.assertEqual(user4.tokens, contract.USER_INITIAL_TOKENS + 0.2 * contract.CONTRIBUTION_TYPE[contribution0.contribution_type]['fee'])


### PR DESCRIPTION
Added the basic functionality for rewarding evaluators according to their reputation:
* field token_fund added to contribution object
* boolean flag REWARD_TOKENS_TO_EVALUATORS added 
* create_evaluation modified to perform the reward in the case the flag above is true and in the case that it is the first time the user votes on the contribution.
* tests added in test_evaluation